### PR TITLE
replaced that.current.brush_extent.map with old version

### DIFF
--- a/client/js/pattern_finder_vis.js
+++ b/client/js/pattern_finder_vis.js
@@ -254,7 +254,8 @@ class PatternFinderVis{
         eventHandler.bind('navigate', (e, d) => {
             that.current.pos = that.current.pos + d;
 
-            that.current.brush_extent = that.current.brush_extent.mp(b => b - d);
+
+            that.current.brush_extent = that.current.brush_extent.map(function (b) {return b - d});
                                                                      
             that.current.selection.cells = that.selected_cells_for_query;
 


### PR DESCRIPTION
This code leads to broken navigation buttons: 
`that.current.brush_extent = that.current.brush_extent.mp(b => b - d);` 
Old version works: 
`that.current.brush_extent = that.current.brush_extent.map(function (b) {return b - d});` works.