### PR TITLE
Move to python3.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ _build_html
 docs/_build
 node_modules
 .idea
-venv3.7
+venv3.7/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _build_html
 docs/_build
 node_modules
 .idea
+venv3.7

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ on OSX 10.11 (El Capitan):
 pip install --user -r requirements.txt
 ```
 
+For python 3.7, install in a virtual environment and follows:
+```
+python3.7 -m venv  venv3.7
+source venv3.7/bin/activate
+pip install -r requirements-3.7.txt
+deactivate
+```
+
 <!--Install [bower](https://bower.io/) (client side) requirements:
 
 ```bash
@@ -57,6 +65,12 @@ python lstm_server.py -dir <datadir>
 ```
 
 For the example dataset, use `python lstm_server.py -dir data`
+
+For Python3.7 you would first activate the virtual env as follows:
+```
+source venv3.7/bin/activate
+python lstm_server.py -dir data
+```
 
 open browser at [http://localhost:8888](http://localhost:8888/client/index.html) - eh voila !
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Also check out our new work on Sequence-to-Sequence models on [github](https://g
 
 ## Install
 
-Please use python 2.7 to install LSTMVis.
+Please use python 3.7 to install LSTMVis.
 
 Clone the repository:
 
@@ -32,17 +32,9 @@ git clone https://github.com/HendrikStrobelt/LSTMVis.git; cd LSTMVis
 Install python (server-side) requirements using [pip](https://pip.pypa.io/en/stable/installing/):
 
 ```bash
-pip install -r requirements.txt
-
-on OSX 10.11 (El Capitan):
-pip install --user -r requirements.txt
-```
-
-For python 3.7, install in a virtual environment and follows:
-```
 python3.7 -m venv  venv3.7
 source venv3.7/bin/activate
-pip install -r requirements-3.7.txt
+pip install -r requirements.txt
 deactivate
 ```
 
@@ -61,16 +53,12 @@ Download & Unzip example dataset(s) into `<LSTMVis>/data/05childbook`:
 start server:
 
 ```bash
+source venv3.7/bin/activate
 python lstm_server.py -dir <datadir>
 ```
 
 For the example dataset, use `python lstm_server.py -dir data`
 
-For Python3.7 you would first activate the virtual env as follows:
-```
-source venv3.7/bin/activate
-python lstm_server.py -dir data
-```
 
 open browser at [http://localhost:8888](http://localhost:8888/client/index.html) - eh voila !
 

--- a/lstm_server.py
+++ b/lstm_server.py
@@ -19,7 +19,6 @@ app = connexion.App(__name__, debug=True)
 
 
 def get_context(**request):
-    print("get_context:IN")
     project = request['project']
     if project not in data_handlers:
         return 'No such project', 404
@@ -48,7 +47,6 @@ def get_context(**request):
             activation_threshold=request['activation']
         )
         res['cells'] = cells
-        print("get_context:OUT")
         return {'request': request, 'results': res}
 
 def cleanup_dict(old_dictionary):
@@ -58,9 +56,6 @@ def cleanup_dict(old_dictionary):
             s=json.dumps(val)
             new_dictionary[key]=val
         except:
-            print(key)
-            print(type(val))
-            print(val)
             if type(val) is dict:
                 new_dictionary[key]=cleanup_dict(val)
             elif type(val) is type({}.keys()):
@@ -69,23 +64,16 @@ def cleanup_dict(old_dictionary):
 
 
 def get_info():
-    print("get_info:IN")    
     res = []
     for key, project in data_handlers.items():
         # print key
-        # print(project.config)
-        # print(cleanup_dict(project.config))
-        # print(json.dumps(cleanup_dict(project.config)))
         res.append({
             'project': key,
             'info':  cleanup_dict(project.config)
         })
-    # print(res)
-    print("get_info:OUT")
     return sorted(res, key=lambda x: x['project'])
 
 def search(**request):
-    print("search:IN")    
     project = request['project']
     res = {}
 
@@ -102,17 +90,14 @@ def search(**request):
         elif dh.config['etc']['regex_search']:
             res = dh.regex_search(request['q'], request['limit'], request['html'])
 
-    print("search:OUT")
     return {'request': request, 'res': res}
 
 
 def match(**request):
-    print("match:IN")
     project = request['project']
     res = {}
 
     if project not in data_handlers:
-        print("match:OUT")
         return 'No such project', 404
 
     else:
@@ -134,7 +119,7 @@ def match(**request):
             constrain_right=request['constraints'][1] > 0
         )
 
-        request_positions = map(lambda x: x['pos'], ranking)
+        request_positions = list(map(lambda x: x['pos'], ranking))
         position_details = dh.get_dimensions(
             pos_array=request_positions,
             source=request['source'],
@@ -152,11 +137,6 @@ def match(**request):
             'fuzzyLengthHistogram': meta['fuzzy_length_histogram'].tolist(),
             'strictLengthHistogram': meta['strict_length_histogram'].tolist()
         }
-        print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
-        print("position_details:")
-        print(position_details)
-        print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
-        print("match:OUT")
         return {'request': request, 'results': res}
 
 
@@ -166,12 +146,10 @@ def send_static(path):
 
     :param path: path from api call
     """
-    print("send_static:CALL")
     return send_from_directory('client/', path)
 
 @app.route('/')
 def redirect_home():
-    print("redirect_home:CALL")
     return redirect('/client/index.html', code=302)
 
 
@@ -183,7 +161,6 @@ def create_data_handlers(directory):
     :param directory: scan directory
     :return: null
     """
-    print("create_data_handlers:IN")
     project_dirs = []
     for root, dirs, files in os.walk(directory):
         if CONFIG_FILE_NAME in files:
@@ -198,7 +175,6 @@ def create_data_handlers(directory):
             if data_handlers[dh_id].config['index']:
                 index_map[dh_id] = data_handlers[dh_id].config['index_dir']
         i += 1
-    print("create_data_handlers:OUT")
 
 
 app.add_api('lstm_server.yaml')

--- a/lstm_server.yaml
+++ b/lstm_server.yaml
@@ -139,7 +139,7 @@ paths:
           type: array
           items:
             type: integer
-          default: 100,101
+          default: [100,101]
 
         - name: activation
           description: threshold to discretize values
@@ -182,7 +182,7 @@ paths:
           minItems: 2
           items:
             type: integer
-#          default: 1,0
+            default: [1,0]
 
 
         - $ref: '#/parameters/transform'

--- a/lstmdata/data_handler.py
+++ b/lstmdata/data_handler.py
@@ -8,7 +8,7 @@ import resource
 import numpy as np
 import re
 
-import helper_functions as hf
+import lstmdata.helper_functions as hf
 
 __author__ = 'Hendrik Strobelt'
 
@@ -29,13 +29,13 @@ class LSTMDataHandler:
         self.dicts_id_value = {}
 
         # open all h5 files
-        h5files = {k: v for k, v in config['files'].iteritems() if (v.endswith('.h5') or v.endswith('.hdf5'))}
-        for key, file_name in h5files.iteritems():
+        h5files = {k: v for k, v in config['files'].items() if (v.endswith('.h5') or v.endswith('.hdf5'))}
+        for key, file_name in h5files.items():
             self.h5_files[key] = h5py.File(os.path.join(directory, file_name), 'r')
 
         # load all dict files of format: value<space>id
-        dict_files = {k: v for k, v in config['files'].iteritems() if (v.endswith('.dict') or v.endswith('.txt'))}
-        for name, file_name in dict_files.iteritems():
+        dict_files = {k: v for k, v in config['files'].items() if (v.endswith('.dict') or v.endswith('.txt'))}
+        for name, file_name in dict_files.items():
             kv = {}
             vk = {}
             with open(os.path.join(directory, file_name), 'r') as f:
@@ -82,7 +82,7 @@ class LSTMDataHandler:
             self.config['index_dir'] = os.path.join(directory, 'indexdir')
 
         if self.config.get('meta', False):
-            for _, m_info in self.config['meta'].iteritems():
+            for _, m_info in self.config['meta'].items():
                 m_info['type'] = m_info.get('type', 'general')
                 m_info['index'] = m_info.get('index', 'self')
                 m_info['vis']['range'] = m_info['vis'].get('range', '0...100')

--- a/lstmdata/data_handler.py
+++ b/lstmdata/data_handler.py
@@ -125,7 +125,6 @@ class LSTMDataHandler:
         :return: [ ...{left: position left, right: position right, pos: requestes pos, data: states matrix},...],[sum_active]
         :rtype: (list, list)
         """
-
         if cell_selection is None:
             cell_selection = []
 
@@ -229,7 +228,6 @@ class LSTMDataHandler:
                 sub_res['embeddings'] = emb if raw else [[round(y, round_values) for y in x] for x in emb.tolist()]
 
             res.append(sub_res)
-
         return res
 
     def get_meta(self, name, pos_array, left=10, right=0):
@@ -340,7 +338,6 @@ class LSTMDataHandler:
                 res[dim] = self.get_words(pos_array, left, right)
             elif dim.startswith('meta_'):
                 res[dim] = self.get_meta(dim[5:], pos_array, left, right)
-
         return res
 
     def query_similar_activations(self, cells, source, activation_threshold=.3,
@@ -356,7 +353,6 @@ class LSTMDataHandler:
         """
         cell_states, data_transformed = self.get_cached_matrix(data_transform, source)
 
-        # print 'before cs:', '{:,}'.format(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
 
         activation_threshold_corrected = activation_threshold
         if not data_transformed:
@@ -364,7 +360,6 @@ class LSTMDataHandler:
 
         cut_off = 2
 
-        # print 'out cs 1:', '{:,}'.format(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
 
         if query_mode == "fast":
             num_of_cells_per_sum = 5  # how many cells are evaluated per batch
@@ -376,7 +371,6 @@ class LSTMDataHandler:
             num_of_cells_per_sum = 1 if num_of_cells_per_sum == 0 else num_of_cells_per_sum
             num_candidates = 10000
 
-        # print 'num_cells', num_of_cells_per_sum
 
         cs_cand = None
         # start = time.time()
@@ -439,12 +433,12 @@ class LSTMDataHandler:
         all_candidates.sort(key=lambda kk: kk[2], reverse=True)
         # for k, v in enumerate(all_candidates):
         #     if v[1] < 1000:
-        #         print 'x', v, k
+        #         print ('x', v, k)
         all_candidates = all_candidates[:num_candidates]
-        # print 'fff'
+        # print ('fff')
         # for k, v in enumerate(all_candidates):
         #     if v[1] < 1000:
-        #         print 'x', v, k
+        #         print ('x', v, k)
 
         cell_count = len(cells)
 
@@ -500,11 +494,11 @@ class LSTMDataHandler:
 
         final_res = list(res[:no_of_results])
 
-        # for elem in res_50:
-        #     print elem, cell_count, -1. * (cell_count - elem[4]) / float(elem[3] + cell_count)
+        # for elem in final_res:
+        #     print(elem, cell_count, -1. * (cell_count - elem[4]) / float(elem[3] + cell_count))
         # print(constrain_left, constrain_right)
         del res
-        # print 'out cs 2:', '{:,}'.format(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+        # print ('out cs 2:', '{:,}'.format(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss))
 
         return final_res, meta
 

--- a/model/preprocess-shifting-window.py
+++ b/model/preprocess-shifting-window.py
@@ -37,7 +37,7 @@ class Indexer:
 
     def write(self, outfile):
         out = open(outfile, "w")
-        items = [(v, k) for k, v in self.d.iteritems()]
+        items = [(v, k) for k, v in self.d.items()]
         items.sort()
         for v, k in items:
             print >>out, k, v

--- a/model/preprocess.py
+++ b/model/preprocess.py
@@ -37,7 +37,7 @@ class Indexer:
 
     def write(self, outfile):
         out = open(outfile, "w")
-        items = [(v, k) for k, v in self.d.iteritems()]
+        items = [(v, k) for k, v in self.d.items()]
         items.sort()
         for v, k in items:
             print >>out, k, v

--- a/requirements-3.7.txt
+++ b/requirements-3.7.txt
@@ -1,0 +1,9 @@
+spacy
+Flask == 1.1.2
+PyYAML == 5.3.1
+Whoosh == 2.7.4
+connexion == 2.7.0
+h5py == 2.10.0
+numpy
+swagger-ui-bundle==0.0.6
+

--- a/requirements-3.7.txt
+++ b/requirements-3.7.txt
@@ -1,9 +1,0 @@
-spacy
-Flask == 1.1.2
-PyYAML == 5.3.1
-Whoosh == 2.7.4
-connexion == 2.7.0
-h5py == 2.10.0
-numpy
-swagger-ui-bundle==0.0.6
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 spacy
-Flask == 0.12.1
-PyYAML == 3.12
+Flask == 1.1.2
+PyYAML == 5.3.1
 Whoosh == 2.7.4
-connexion == 1.1.5
-h5py == 2.7.0
-numpy == 1.12.1
+connexion == 2.7.0
+h5py == 2.10.0
+numpy
+swagger-ui-bundle==0.0.6
+

--- a/tools/nlp_annotate.py
+++ b/tools/nlp_annotate.py
@@ -36,7 +36,7 @@ for annotations, n in ((annotations_pos, "pos"), (annotations_ner, "ner")):
 
 
     with open(n+".dict", "w") as df:
-        for k, v in anno_dict.iteritems():
+        for k, v in anno_dict.items():
             print >>df, k, v
 
     with h5py.File(n+".h5", "w") as vf:

--- a/tools/txt_to_hdf5_dict.py
+++ b/tools/txt_to_hdf5_dict.py
@@ -39,7 +39,7 @@ class Indexer:
 
     def write(self, outfile):
         out = open(outfile, "w")
-        items = [(v, k) for k, v in self.d.iteritems()]
+        items = [(v, k) for k, v in self.d.items()]
         items.sort()
         for v, k in items:
             print >>out, k, v


### PR DESCRIPTION
Small changes to allow moving to Python3.7 (Python2.7 is already depricated in most environments).
- Requirements adjusted to latest version, and to include "swagger-ui-bundle" per warning thrown at startup.
- The previous version of the project.config included nested dict_items structures which are not directly serializable in Python3 so a workaround was introduced.
- Calls to iteritems() were replaced by items() for Python3
- maps are no longer passed around due to differences between Python2/Python3. Instead we use list(map())
- Localhost should be "127.0.0.1" for WSL on PC. Not sure if this breaks running on a mac.

